### PR TITLE
provide plone.app.caching etag "editmode".

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,6 +41,15 @@ You may want to place an action somewhere for toggling the edit mode - this
 integration is not done by ``collective.editmodeswitcher``.
 
 
+Caching
+-------
+
+``collective.editmodeswitcher`` provides a ``plone.app.caching`` etag adapter
+named ``editmode``.
+This etag can be used in the caching configuration in order to make the cache
+flush when switching the edit mode.
+
+
 
 Links
 -----

--- a/collective/editmodeswitcher/caching.py
+++ b/collective/editmodeswitcher/caching.py
@@ -1,0 +1,18 @@
+from plone.app.caching.interfaces import IETagValue
+from zope.component import adapts
+from zope.component.hooks import getSite
+from zope.interface import implements
+from zope.interface import Interface
+
+
+class EditModeEtag(object):
+    implements(IETagValue)
+    adapts(Interface, Interface)
+
+    def __init__(self, published, request):
+        self.published = published
+        self.request = request
+
+    def __call__(self):
+        switcher = getSite().restrictedTraverse('@@switch-editmode')
+        return switcher.get_state()

--- a/collective/editmodeswitcher/configure.zcml
+++ b/collective/editmodeswitcher/configure.zcml
@@ -19,4 +19,6 @@
         allowed_attributes="get_state"
     />
 
+    <adapter factory=".caching.EditModeEtag" name="editmode" />
+
 </configure>

--- a/collective/editmodeswitcher/tests/__init__.py
+++ b/collective/editmodeswitcher/tests/__init__.py
@@ -10,6 +10,7 @@ class FunctionalTestCase(TestCase):
 
     def setUp(self):
         self.portal = self.layer['portal']
+        self.request = self.layer['request']
 
     def grant(self, *roles):
         setRoles(self.portal, TEST_USER_ID, list(roles))

--- a/collective/editmodeswitcher/tests/test_caching.py
+++ b/collective/editmodeswitcher/tests/test_caching.py
@@ -1,0 +1,17 @@
+from collective.editmodeswitcher.config import COOKIE_NAME
+from collective.editmodeswitcher.tests import FunctionalTestCase
+from plone.app.caching.interfaces import IETagValue
+from zope.component import getMultiAdapter
+
+
+class TestCaching(FunctionalTestCase):
+
+    def test_editmode_etag(self):
+        view = self.portal.restrictedTraverse('@@view')
+        adapter = getMultiAdapter((view, self.request),
+                                  IETagValue,
+                                  name='editmode')
+
+        self.assertEquals('enabled', adapter())
+        self.request.cookies[COOKIE_NAME] = '1'
+        self.assertEquals('disabled', adapter())

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.0.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Provide plone.app.caching etag "editmode". [jone]
 
 
 1.0.2 (2016-02-12)


### PR DESCRIPTION
The "editmode" etag can be used when plone.app.caching is enabled for editors in order to make the cache flush when switching the editmode.
